### PR TITLE
Allow bundle version to be injected

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -4,8 +4,18 @@ var command = {
   builder: {},
   run: function (options, done) {
     var pkg = require("../../package.json");
+    var solcpkg = require("solc/package.json");
 
-    options.logger.log("Truffle v" + pkg.version);
+    var bundle_version = "N/A";
+
+    // NOTE: Webpack will replace BUNDLE_VERSION with a string.
+    if (typeof BUNDLE_VERSION != "undefined") {
+      bundle_version = BUNDLE_VERSION;
+    }
+
+    options.logger.log("Truffle v" + pkg.version + ", bundle version: " + bundle_version);
+    options.logger.log("Solidity v" + solcpkg.version + " (solc-js)");
+
     done();
   }
 }


### PR DESCRIPTION
- When running non-bundled, bundle version will be N/A
- When running in a bundle, bundle will replace BUNDLE_VERSION in the code with the version string

Also print solidity version per truffle/#409

<img width="796" alt="screen shot 2017-06-08 at 2 20 08 pm" src="https://user-images.githubusercontent.com/92629/26951343-9e31a1ae-4c55-11e7-840d-4a3054f3ff5e.png">
<img width="783" alt="screen shot 2017-06-08 at 2 19 52 pm" src="https://user-images.githubusercontent.com/92629/26951344-9e4c284e-4c55-11e7-8b39-1b37c76a6fc4.png">
