### PR TITLE
Run test command if --tests flag is specified on watch

### DIFF
--- a/lib/commands/watch.js
+++ b/lib/commands/watch.js
@@ -1,3 +1,5 @@
+var testCommand = require('./test');
+
 var command = {
   command: 'watch',
   description: 'Watch filesystem for changes and rebuild the project automatically',
@@ -37,6 +39,10 @@ var command = {
       path.join(config.working_directory, "truffle-config.js"),
       path.join(config.working_directory, "truffle.js")
     ];
+console.log(JSON.stringify(config))
+    if(config.tests) {
+      watchPaths.push(path.join(config.working_directory, "test/**/*"));
+    }
 
     chokidar.watch(watchPaths, {
       ignored: /[\/\\]\./, // Ignore files prefixed with "."
@@ -60,6 +66,17 @@ var command = {
         return;
       }
 
+      if(config.tests && (needs_rebuild || needs_recompile)){
+        needs_rebuild = false;
+        needs_recompile = false;
+        working = true;
+
+        testCommand.run(options,function(err){
+          if(err) printFailure(err);
+          working = false;
+        });
+      }
+      
       if (needs_rebuild == true) {
         needs_rebuild = false;
 

--- a/test/ethpm.js
+++ b/test/ethpm.js
@@ -77,22 +77,22 @@ describe('EthPM integration', function() {
     });
   });
 
-  // afterEach("stop ipfs server", function(done) {
-  //   this.timeout(10000);
-  //
-  //   var called = false;
-  //   // The callback gets called more than once...
-  //   try {
-  //     ipfs_daemon.stopDaemon(function() {
-  //       if (called == false) {
-  //         called = true;
-  //         done();
-  //       }
-  //     });
-  //   } catch (e) {
-  //     // do nothing
-  //   }
-  // });
+  afterEach("stop ipfs server", function(done) {
+    this.timeout(10000);
+  
+    var called = false;
+    // The callback gets called more than once...
+    try {
+      ipfs_daemon.stopDaemon(function() {
+        if (called == false) {
+          called = true;
+          done();
+        }
+      });
+    } catch (e) {
+      // do nothing
+    }
+  });
 
   it("successfully installs single dependency from EthPM", function(done) {
     this.timeout(20000); // Giving ample time for requests to time out.


### PR DESCRIPTION

Add --tests flag to watch.  In issue 269 people were expecting --tests to run tests after a rebuild. I've added this. Note it diverts to the test task rather than rebuilding then passing to tests (where we would have to tell it not to rebuild), so that's up for discussion.

Also re-enabled ipfs server cleanup on test run (tests always failing until I did this).