### PR TITLE
Add --show-events flag to test command

### DIFF
--- a/lib/testing/testrunner.js
+++ b/lib/testing/testrunner.js
@@ -133,9 +133,12 @@ TestRunner.prototype.startTest = function(mocha, callback) {
 };
 
 TestRunner.prototype.endTest = function(mocha, callback) {
+
   var self = this;
 
-  if (mocha.currentTest.state != "failed") {
+  var showEvents = self.config["show-events"];
+
+  if (mocha.currentTest.state != "failed" && !showEvents ) {
     return callback();
   }
 


### PR DESCRIPTION
Flag to show events when tests are passing described in waffle 186.

`truffle test --show-events`