### PR TITLE
Use the bundled version as the main version.

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -13,7 +13,7 @@ var command = {
       bundle_version = BUNDLE_VERSION;
     }
 
-    options.logger.log("Truffle v" + pkg.version + ", bundle version: " + bundle_version);
+    options.logger.log("Truffle v" + bundle_version + " (core: " + pkg.version + ")");
     options.logger.log("Solidity v" + solcpkg.version + " (solc-js)");
 
     done();


### PR DESCRIPTION
This will be the version users interact with the most, so let's highlight it instead.
<img width="787" alt="screen shot 2017-06-30 at 9 54 31 am" src="https://user-images.githubusercontent.com/92629/27745941-237ec6c2-5d7a-11e7-90fc-ef23047ae875.png">

