### PR TITLE
Fix `truffle create migration`.

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -92,7 +92,7 @@ var Create = {
     to += ".js";
     to = path.join(directory, to);
 
-    copy(from, to, {clobber: false}, callback);
+    copy.file(from, to, callback);
   }
 }
 

--- a/test/create.js
+++ b/test/create.js
@@ -58,7 +58,7 @@ describe('create', function() {
       dir.files(config.migrations_directory, function(err, files) {
         var found = false;
         files.forEach(function(file) {
-          if (file.indexOf("my_new_migration") > 0) {
+          if (file.match(/my_new_migration\.js$/)) {
             var file_data = fs.readFileSync(file, {encoding: "utf8"});
             assert.isNotNull(file_data, "File's data is null");
             assert.notEqual(file_data, "", "File's data is blank");


### PR DESCRIPTION
After creating a migration the file ends up in the wrong location.

```
$ truffle create migration HelloWorld
$ git st
On branch master
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	migrations/1499201171_hello_world.js/migration.js

```

Which is ignore by the `migrate` command:

```
$ truffle migrate --reset
Compiling ./contracts/HelloWorld.sol...
Compiling ./contracts/Migrations.sol...
Writing artifacts to ./build/contracts

Using network 'development'.

Running migration: 1_initial_migration.js
  Deploying Migrations...
  Migrations: 0xaec3202cde63767fe4b970d5d26464d84e0bda11
Saving successful migration to network...
Saving artifacts...
```

This PR fixes the core test to make it more strict and fix the offending
code.

The following is the result using this branch:

```
$ truffle create migration HelloWorld
$ git st
On branch master
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	migrations/1499201626_hello_world.js

$ truffle migrate --reset
Using network 'development'.

Running migration: 1_initial_migration.js
  Replacing Migrations...
  Migrations: 0x526399b80b798f0baa9b88a4936402f65adb86f4
Saving successful migration to network...
Saving artifacts...
Running migration: 1499201626_hello_world.js
  Deploying HelloWorld...
  HelloWorld: 0x1ca72d93fc7b0605deed12986f8b405ff1ce1a9c
Saving successful migration to network...
Saving artifacts...
```