### PR TITLE
Infer command entered based on initial letters if there isn't a direct match

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -21,15 +21,43 @@ Command.prototype.getCommand = function(str) {
     return null;
   }
 
-  var name = argv._[0];
-  var command = this.commands[name];
+  var input = argv._[0];
+  var chosenCommand = null;
 
-  if (command == null) {
+  // If the command wasn't specified directly, go through a process
+  // for inferring the command.
+  if (this.commands[input]) {
+    chosenCommand = input;
+  } else {
+    var currentLength = 1;
+    var availableCommandNames = Object.keys(this.commands);
+
+    // Loop through each letter of the input until we find a command
+    // that uniquely matches.
+    while (currentLength <= input.length) {
+      // Gather all possible commands that match with the current length
+      var possibleCommands = availableCommandNames.filter(function(possibleCommand) {
+        return possibleCommand.substring(0, currentLength) == input.substring(0, currentLength);
+      });
+
+      // Did we find only one command that matches? If so, use that one.
+      if (possibleCommands.length == 1) {
+        chosenCommand = possibleCommands[0];
+        break;
+      }
+
+      currentLength += 1;
+    }
+  }
+
+  if (chosenCommand == null) {
     return null;
   }
 
+  var command = this.commands[chosenCommand];
+
   return {
-    name: name,
+    name: input,
     argv: argv,
     command: command
   };

--- a/test/commands.js
+++ b/test/commands.js
@@ -1,0 +1,40 @@
+var Command = require("../lib/command");
+var commands = require("../lib/commands");
+var commander = new Command(commands);
+var assert = require("assert");
+
+describe("Commander", function() {
+  before("assert preconditions", function() {
+    // These commands are expected to exist in tests.
+    assert.notEqual(commands.migrate, null);
+    assert.notEqual(commands.compile, null);
+    assert.notEqual(commands.console, null);
+  });
+
+  it("will infer commands based on initial letters entered", function() {
+    var actualCommand = commander.getCommand("m").command;
+    assert.equal(actualCommand, commands.migrate);
+  });
+
+  it("will infer commands based on initial letters entered, even when typos exist later", function() {
+    var actualCommand = commander.getCommand("complie").command;
+    assert.equal(actualCommand, commands.compile);
+  });
+
+  it("will NOT infer a command if not given enough information", function() {
+    // Note: "co" matches "console" and "compile"
+    var actualCommand = commander.getCommand("co");
+    assert.equal(actualCommand, null);
+  });
+
+  it("will infer commands based on initial letters entered, given matches for shorter substrings", function() {
+    // Note: "co" matches "console" and "compile"
+    var actualCommand = commander.getCommand("com").command;
+    assert.equal(actualCommand, commands.compile);
+  });
+
+  it("will ignore inferring if full command is specified", function() {
+    var actualCommand = commander.getCommand("console").command;
+    assert.equal(actualCommand, commands.console);
+  });
+});


### PR DESCRIPTION
See trufflesuite/truffle#491.

Try the following commands:

```
$ truffle m   // will choose "migrate"
$ truffle com // will choose "compile"
$ truffle c   // won't infer because too many things match
```

Regarding that last command: We **could** have the algorithm choose the first command that matches if there are multiple matches. i.e., if "c" matches `compile`, `console` and `create`, then `compile` would be the first in the list. Aside: Could this potentially be dangerous? 

Either that or we leave the algorithm in to handle typos and also add specific first letter matching if only a single letter is entered.