### PR TITLE
Exposing TRUFFLE_NETWORK in the node process

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -23,6 +23,8 @@ var Environment = {
       config.network = "development";
     }
 
+    process.env.TRUFFLE_NETWORK = config.network;
+
     if (!config.network) {
       return callback(new Error("No network specified. Cannot determine current network."));
     }


### PR DESCRIPTION
Hello there,

I'm proposing a quick work around, so we can *work around* the current lack of flexibility with the environment issue. The idea behind this patch is to expose the selected *network* as an environment variable, so that the process can introspect itself and be aware of the current environment.
This is a practice coming from the *rails* community. The command:
    $ rails c production
will seed RAILS_ENV with production.
Thank you for the amazing work!
Best,

Ludovic
