### PR TITLE
exit process with 0 code explicitly in case of successful command execution

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,4 +34,6 @@ command.run(process.argv.slice(2), options, function(err) {
     }
     process.exit(1);
   }
+
+  process.exit(0);
 });


### PR DESCRIPTION
Functions scheduled via `setTimeout` will prevent nodejs app from exiting.
In case `truffle.js` config contains code which calls `setTimeout`
(e.g. `web3-provider-engine` starts block tracker) truffle CLI
will 'hang' after successful execution of a command.