### PR TITLE
Fix console misbehavior

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -124,7 +124,7 @@ Console.prototype.resetContractsInConsoleContext = function(abstractions) {
 Console.prototype.interpret = function(cmd, context, filename, callback) {
   var self = this;
 
-  if (this.command.getCommand(cmd.trim()) != null) {
+  if (this.command.getCommand(cmd.trim(), this.options.noAliases) != null) {
     return self.command.run(cmd.trim(), this.options, function(err) {
       if (err) {
         // Perform error handling ourselves.

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -53,7 +53,9 @@ ReplManager.prototype.start = function(options) {
       // then ensure the process is completely killed. Once the repl exits,
       // the process is in a bad state and can't be recovered (e.g., stdin is closed).
       var doneFunctions = self.contexts.map(function(context) {
-        return context.done || function() {};
+        return context.done ?
+          function() { context.done(); } :
+          function() {};
       });
       async.series(doneFunctions, function(err) {
         process.exit();


### PR DESCRIPTION
- `noAliases` got lost when `lib/repl.js` got split up
- `async.series` seems to pass an argument to each of the given task functions, a callback. This appears to be unnecessary.