### PR TITLE
Make `truffle develop` spawn a server in a child process

### DIFF
--- a/chain.js
+++ b/chain.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+var TestRPC = require("ethereumjs-testrpc");
+
+// This script takes one argument: A strinified JSON object meant 
+// to be parsed and then passed to TestRPC.server(). 
+
+if (process.argv.length <= 2) {
+  throw new Error("Fatal: No arguments passed to default environment; please contact the Truffle developers for help.");
+}
+
+var options;
+
+try {
+  options = JSON.parse(process.argv[2]);
+} catch (e) {
+  throw new Error("Fatal: Error parsing arguments; please contact the Truffle developers for help.");
+}
+
+var server = TestRPC.server(options);
+
+server.listen(options.port, options.hostname, function(err, state) {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  
+  console.log("Truffle Develop started.");
+  console.log();
+});
+
+process.on('uncaughtException', function(e) {
+  console.error(e.stack);
+  process.exit(1);
+})
+
+// See http://stackoverflow.com/questions/10021373/what-is-the-windows-equivalent-of-process-onsigint-in-node-js
+if (process.platform === "win32") {
+  require("readline").createInterface({
+    input: process.stdin,
+    output: process.stdout
+  })
+  .on("SIGINT", function () {
+    process.emit("SIGINT");
+  });
+}
+
+process.on("SIGINT", function () {
+  // graceful shutdown; error if neccessary
+  server.close(function(err) {
+    if (err) {
+      console.error(err.stack || err);
+      process.exit(1);
+    } else {
+      process.exit();
+    }
+  });
+});

--- a/lib/commands/develop.js
+++ b/lib/commands/develop.js
@@ -33,18 +33,18 @@ var command = {
     });
 
     // use local environment instead of detecting config environment
-    Environment.local(config, function(err, cleanup) {
+    Environment.local(config, function(err, child_process) {
       if (err) return done(err);
-
-      config.logger.log("Truffle Develop started.");
-      config.logger.log();
 
       var c = new Console(console_commands, config.with({
         noAliases: true
       }));
-      c.start(function() { cleanup(done); });
-    });
 
+      c.start(done);
+      c.on("exit", function() {
+        child_process.kill();
+      });
+    });
   }
 }
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -10,8 +10,16 @@ var TruffleError = require("truffle-error");
 var fs = require("fs");
 var os = require("os");
 var path = require("path");
+var EventEmitter = require("events");
+var inherits = require("util").inherits;
+
+inherits(Console, EventEmitter);
 
 function Console(tasks, options) {
+  EventEmitter.call(this);
+
+  var self = this;
+
   expect.options(options, [
     "working_directory",
     "contracts_directory",
@@ -31,6 +39,11 @@ function Console(tasks, options) {
 
   this.web3 = new Web3();
   this.web3.setProvider(options.provider);
+
+  // Bubble the ReplManager's exit event
+  this.repl.on("exit", function() {
+    self.emit("exit");
+  });
 };
 
 Console.prototype.start = function(callback) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -11,8 +11,14 @@ var fs = require("fs");
 var os = require("os");
 var path = require("path");
 var async = require("async");
+var EventEmitter = require("events");
+var inherits = require("util").inherits;
+
+inherits(ReplManager, EventEmitter);
 
 function ReplManager(options) {
+  EventEmitter.call(this);
+
   expect.options(options, [
     "working_directory",
     "contracts_directory",
@@ -62,6 +68,11 @@ ReplManager.prototype.start = function(options) {
       });
     });
   }
+
+  // Bubble the internal repl's exit event
+  this.repl.on("exit", function() {
+    self.emit("exit");
+  });
 
   this.repl.setPrompt(options.prompt);
   this.setContextVars(options.context || {});


### PR DESCRIPTION
Fire up a chain in a child process. This PR:

* Creates `chain.js`, which is a simple script that fires up a TestRPC server. It accepts only one argument, which is a stringified JSON object that, when parsed, becomes the object passed to `TestRPC.server()`
* Calls `chain.js` when `Environment.local()` is called.
* Bubbles `exit` events from the REPL, so that `truffle develop` can kill the child process when the REPL quits.  
* Gracefully handles shutdown of the main process to ensure the child process doesn't keep the main process open. 
* Detects whether or not we're running in a bundle. If so, the location of the `chain.js` file will exist in a location relative to the `cli.bundle.js` file within the `truffle` project. Details on this to come in a new PR.

Good test of whether or not this works:

```
$ truffle develop
$ truffle(develop)> web3.eth.accounts
```

Note that last command is synchronous! (and it works 🎉)
