### PR TITLE
Fix test on Windows. See https://github.com/nodejs/node/issues/5561

### DIFF
--- a/test/compile.js
+++ b/test/compile.js
@@ -63,7 +63,7 @@ describe("compile", function() {
     var file_to_update = path.resolve(path.join(config.contracts_directory, "MetaCoin.sol"));
 
     // Update the modification time to simulate an edit.
-    var newTime = new Date().getTime();
+    var newTime = new Date();
     fs.utimesSync(file_to_update, newTime, newTime);
 
     Contracts.compile(config.with({


### PR DESCRIPTION
TL;DR: date passed to `utimes` must be a Date object.