### PR TITLE
Allow multiple `truffle develop` sessions to connect to the same managed TestRPC

### DIFF
--- a/chain.js
+++ b/chain.js
@@ -193,15 +193,11 @@ Logger.prototype.subscribe = function(callback) {
   this.flush(callback);
 
   var unsubscribe = function() {
-    self.unsubscribe(subscriberID);
+    delete self.subscribers[subscriberID];
   };
 
   return unsubscribe;
 };
-
-Logger.prototype.unsubscribe = function(subscriberID) {
-  delete this.subscribers[subscriberID];
-}
 
 Logger.prototype.flush = function(callback) {
   var messages = this.messages;

--- a/chain.js
+++ b/chain.js
@@ -2,8 +2,8 @@
 
 var TestRPC = require("ethereumjs-testrpc");
 
-// This script takes one argument: A strinified JSON object meant 
-// to be parsed and then passed to TestRPC.server(). 
+// This script takes one argument: A strinified JSON object meant
+// to be parsed and then passed to TestRPC.server().
 
 if (process.argv.length <= 2) {
   throw new Error("Fatal: No arguments passed to default environment; please contact the Truffle developers for help.");
@@ -24,7 +24,7 @@ server.listen(options.port, options.hostname, function(err, state) {
     console.error(err);
     process.exit(1);
   }
-  
+
   console.log("Truffle Develop started.");
   console.log();
 });

--- a/chain.js
+++ b/chain.js
@@ -32,7 +32,7 @@ options.gasLimit = options.gasLimit || 0x47e7c4;
 /*
  * IPC server
  */
-function Supervisor(networkID, ipcConfig, testrpcOptions) {
+function Supervisor(networkID, ipcConfig) {
   var self = this;
 
   // init IPC

--- a/chain.js
+++ b/chain.js
@@ -87,8 +87,20 @@ Supervisor.prototype.start = function() {
   ipc.server.start();
 }
 
-Supervisor.prototype.emit = function(socket, message, data) {
+Supervisor.prototype.emit = function(socket, message, data, options) {
+  options = options || {};
+  options.silent = options.silent || false;
+
+  // possibly override silent
+  var currentlySilent = this.ipc.config.silent;
+  if (options.silent) {
+    this.ipc.config.silent = true;
+  }
+
   this.ipc.server.emit(socket, message, data);
+
+  // reset
+  this.ipc.config.silent = currentlySilent;
 };
 
 Supervisor.prototype.exit = function() {

--- a/chain.js
+++ b/chain.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var ipc = require("node-ipc");
+var IPC = require("node-ipc").IPC;
 var TestRPC = require("ethereumjs-testrpc");
 
 // This script takes one argument: A strinified JSON object meant
@@ -35,7 +35,11 @@ process.on('uncaughtException', function(e) {
   process.exit(1);
 })
 
-ipc.config.id = 'truffleDevelop';
+var ipc = new IPC();
+
+var networkID = 'truffleDevelop';
+
+ipc.config.id = networkID;
 ipc.config.retry = 1500;
 ipc.config.silent = true;
 

--- a/chain.js
+++ b/chain.js
@@ -4,32 +4,9 @@ var IPC = require("node-ipc").IPC;
 var TestRPC = require("ethereumjs-testrpc");
 var path = require("path");
 
-function Server(networkID, ipcConfig) {
-  var self = this;
-
-  this.ipc = new IPC();
-
-  this.ipc.config.id = networkID;
-
-  // set config
-  Object.keys(ipcConfig).forEach(function(key) {
-    self.ipc.config[key] = ipcConfig[key];
-  });
-
-  // socket filename
-}
-
-Server.prototype.start = function(callback) {
-  var ipc = this.ipc;
-
-  var dirname = ipc.config.socketRoot;
-  var basename = `${ipc.config.appspace}${ipc.config.id}`;
-  var servePath = path.join(dirname, basename);
-
-  ipc.serve(servePath, function() { callback(ipc); });
-
-  ipc.server.start();
-}
+/*
+ * Options
+ */
 
 // This script takes one argument: A strinified JSON object meant
 // to be parsed and then passed to TestRPC.server().
@@ -50,55 +27,160 @@ options.network_id = options.network_id || 4447;
 options.seed = options.seed || "yum chocolate";
 options.gasLimit = options.gasLimit || 0x47e7c4;
 
+
+
+/*
+ * IPC server
+ */
+function Supervisor(networkID, ipcConfig, testrpcOptions) {
+  var self = this;
+
+  // init IPC
+  this.ipc = new IPC();
+  this.ipc.config.id = networkID;
+  // set config
+  Object.keys(ipcConfig).forEach(function(key) {
+    self.ipc.config[key] = ipcConfig[key];
+  });
+
+  this.mixins = [];
+}
+
+Supervisor.prototype.mixin = function(mixin) {
+  this.mixins.push(mixin);
+};
+
+Supervisor.prototype.start = function() {
+  var self = this;
+
+  var ipc = this.ipc;
+
+  // socket filename
+  var dirname = ipc.config.socketRoot;
+  var basename = `${ipc.config.appspace}${ipc.config.id}`;
+  var servePath = path.join(dirname, basename);
+
+  ipc.serve(servePath, function() {
+    self.mixins.forEach(function(mixin) {
+      if (mixin.start) {
+        mixin.start(self);
+      }
+    });
+
+    ipc.server.on('connect', function(socket) {
+      self.mixins.forEach(function(mixin) {
+        if (mixin.connect) {
+          mixin.connect(self, socket);
+        }
+      });
+    });
+
+    ipc.server.on('socket.disconnected', function() {
+      self.mixins.forEach(function(mixin) {
+        if (mixin.disconnect) {
+          mixin.disconnect(self);
+        }
+      });
+    });
+  });
+
+  ipc.server.start();
+}
+
+Supervisor.prototype.emit = function(socket, message, data) {
+  this.ipc.server.emit(socket, message, data);
+};
+
+Supervisor.prototype.exit = function() {
+  var self = this;
+
+  this.ipc.server.stop();
+  this.mixins.forEach(function(mixin) {
+    if (mixin.exit) {
+      mixin.exit(self);
+    }
+  });
+}
+
+/*
+ * Lifecycle
+ * (quit on last connection)
+ */
+function LifecycleMixin() {
+  var self = this;
+}
+
+LifecycleMixin.prototype.start = function(supervisor) {
+  this.connections = 0;
+};
+
+LifecycleMixin.prototype.connect = function(supervisor) {
+  this.connections++;
+};
+
+LifecycleMixin.prototype.disconnect = function(supervisor) {
+  this.connections--;
+
+  if (this.connections <= 0) {
+    supervisor.exit();
+  }
+};
+
+
+/*
+ * TestRPC Server
+ */
+function TestRPCMixin(options) {
+  this.testrpc = TestRPC.server(options);
+}
+
+
+TestRPCMixin.prototype.start = function(supervisor) {
+  var self = this;
+
+  this.ready = new Promise(function(accept, reject) {
+    self.testrpc.listen(options.port, options.hostname, function(err, state) {
+      if (err) {
+        reject(err);
+      }
+
+      accept(state);
+    });
+  });
+};
+
+TestRPCMixin.prototype.connect = function(supervisor, socket) {
+  var self = this;
+  this.ready.then(function() {
+    supervisor.emit(socket, 'app.ready');
+  });
+}
+
+TestRPCMixin.prototype.exit = function(supervisor) {
+  this.testrpc.close(function(err) {
+    if (err) {
+      console.error(err.stack || err);
+      process.exit(1);
+    } else {
+      process.exit();
+    }
+  });
+};
+
+
+/*
+ * Process event handling
+ */
 process.on('uncaughtException', function(e) {
   console.error(e.stack);
   process.exit(1);
 })
 
-var server = new Server("truffleDevelop", {retry: 1500});
 
-server.start(function(ipc) {
-
-  var connected = 0;
-
-  var testrpc = TestRPC.server(options);
-
-  var ready = new Promise(function(accept, reject) {
-    testrpc.listen(options.port, options.hostname, function(err, state) {
-      if (err) {
-        reject(err);
-      }
-
-      accept();
-    });
-  });
-
-  ready.catch(function(err) {
-    console.error(err);
-    process.exit(1);
-  });
-
-  ipc.server.on('connect', function(socket) {
-    connected++;
-
-    ready.then(function() {
-      ipc.server.emit(socket, 'app.ready');
-    });
-  });
-
-  ipc.server.on('socket.disconnected', function() {
-    connected--;
-
-    if (connected <= 0) {
-      ipc.server.stop();
-      testrpc.close(function(err) {
-        if (err) {
-          console.error(err.stack || err);
-          process.exit(1);
-        } else {
-          process.exit();
-        }
-      });
-    }
-  });
-});
+/*
+ * Main
+ */
+var supervisor = new Supervisor("truffleDevelop", {retry: 1500});
+supervisor.mixin(new LifecycleMixin());
+supervisor.mixin(new TestRPCMixin(options));
+supervisor.start();

--- a/chain.js
+++ b/chain.js
@@ -5,18 +5,22 @@ var TestRPC = require("ethereumjs-testrpc");
 
 // This script takes one argument: A strinified JSON object meant
 // to be parsed and then passed to TestRPC.server().
-
-if (process.argv.length <= 2) {
-  throw new Error("Fatal: No arguments passed to default environment; please contact the Truffle developers for help.");
-}
-
 var options;
-
 try {
-  options = JSON.parse(process.argv[2]);
+  if (process.argv[2]) {
+    options = JSON.parse(process.argv[2]);
+  } else {
+    options = {};
+  }
 } catch (e) {
   throw new Error("Fatal: Error parsing arguments; please contact the Truffle developers for help.");
 }
+
+options.host = options.host || "localhost";
+options.port = options.port || 9545;
+options.network_id = options.network_id || 4447;
+options.seed = options.seed || "yum chocolate";
+options.gasLimit = options.gasLimit || 0x47e7c4;
 
 var server = TestRPC.server(options);
 

--- a/lib/commands/develop.js
+++ b/lib/commands/develop.js
@@ -2,10 +2,6 @@ var command = {
   command: 'develop',
   description: 'Open a console with a local TestRPC',
   builder: {
-    db: {
-      type: "string",
-      describe: "Path to save persistent chain data"
-    }
   },
   run: function (options, done) {
     var Config = require("truffle-config");

--- a/lib/commands/develop.js
+++ b/lib/commands/develop.js
@@ -2,13 +2,18 @@ var command = {
   command: 'develop',
   description: 'Open a console with a local TestRPC',
   builder: {
+    log: {
+      type: "boolean",
+      default: false
+    },
+    "log-ipc": {
+      type: "boolean",
+      default: false
+    }
   },
-  run: function (options, done) {
-    var Config = require("truffle-config");
+  runConsole: function(config, testrpcOptions, done) {
     var Console = require("../console");
     var Environment = require("../environment");
-
-    var config = Config.detect(options);
 
     var commands = require("./index")
     var excluded = [
@@ -28,8 +33,7 @@ var command = {
       console_commands[name] = commands[name];
     });
 
-    // use local environment instead of detecting config environment
-    Environment.develop(config, function(err) {
+    Environment.develop(config, testrpcOptions, function(err) {
       if (err) return done(err);
 
       var c = new Console(console_commands, config.with({
@@ -40,6 +44,48 @@ var command = {
       c.on("exit", function() {
         process.exit();
       });
+    });
+  },
+  run: function (options, done) {
+    var Config = require("truffle-config");
+    var Develop = require("../develop");
+
+    var config = Config.detect(options);
+
+    var ipcOptions = { logging: {} };
+
+    if (options.log) {
+      ipcOptions.logging.testrpc = function(message) {
+        console.log(message);
+      }
+    }
+
+    if (options["log-ipc"]) {
+      ipcOptions.logging.ipc = function(message) {
+        console.log(message);
+      }
+    }
+
+    var testrpcOptions = {
+      host: "localhost",
+      port: 9545,
+      network_id: 4447,
+      seed: "yum chocolate",
+      gasLimit: config.gas
+    };
+
+    Develop.connectOrStart(ipcOptions, testrpcOptions, function(started) {
+      if (started) {
+        config.logger.log("Truffle Develop started.");
+        config.logger.log();
+      } else {
+        config.logger.log("Connected to exiting Truffle Develop session.");
+        config.logger.log();
+      }
+
+      if (!options.log && !options['log-ipc']) {
+        command.runConsole(config, testrpcOptions, done);
+      }
     });
   }
 }

--- a/lib/commands/develop.js
+++ b/lib/commands/develop.js
@@ -6,9 +6,9 @@ var command = {
       type: "boolean",
       default: false
     },
-    "log-ipc": {
+    console: {
       type: "boolean",
-      default: false
+      default: undefined
     }
   },
   runConsole: function(config, testrpcOptions, done) {
@@ -52,18 +52,12 @@ var command = {
 
     var config = Config.detect(options);
 
-    var ipcOptions = { logging: {} };
+    var ipcOptions = {
+      log: options.log
+    };
 
-    if (options.log) {
-      ipcOptions.logging.testrpc = function(message) {
-        console.log(message);
-      }
-    }
-
-    if (options["log-ipc"]) {
-      ipcOptions.logging.ipc = function(message) {
-        console.log(message);
-      }
+    if (options.console === undefined) {
+      options.console = !options.log;
     }
 
     var testrpcOptions = {
@@ -83,7 +77,7 @@ var command = {
         config.logger.log();
       }
 
-      if (!options.log && !options['log-ipc']) {
+      if (options.console) {
         command.runConsole(config, testrpcOptions, done);
       }
     });

--- a/lib/commands/develop.js
+++ b/lib/commands/develop.js
@@ -33,7 +33,7 @@ var command = {
     });
 
     // use local environment instead of detecting config environment
-    Environment.local(config, function(err, child_process) {
+    Environment.develop(config, function(err) {
       if (err) return done(err);
 
       var c = new Console(console_commands, config.with({
@@ -42,7 +42,7 @@ var command = {
 
       c.start(done);
       c.on("exit", function() {
-        child_process.kill();
+        done();
       });
     });
   }

--- a/lib/commands/develop.js
+++ b/lib/commands/develop.js
@@ -5,10 +5,6 @@ var command = {
     log: {
       type: "boolean",
       default: false
-    },
-    console: {
-      type: "boolean",
-      default: undefined
     }
   },
   runConsole: function(config, testrpcOptions, done) {
@@ -56,10 +52,6 @@ var command = {
       log: options.log
     };
 
-    if (options.console === undefined) {
-      options.console = !options.log;
-    }
-
     var testrpcOptions = {
       host: "localhost",
       port: 9545,
@@ -77,7 +69,7 @@ var command = {
         config.logger.log();
       }
 
-      if (options.console) {
+      if (!options.log) {
         command.runConsole(config, testrpcOptions, done);
       }
     });

--- a/lib/commands/develop.js
+++ b/lib/commands/develop.js
@@ -42,7 +42,7 @@ var command = {
 
       c.start(done);
       c.on("exit", function() {
-        done();
+        process.exit();
       });
     });
   }

--- a/lib/develop.js
+++ b/lib/develop.js
@@ -24,10 +24,6 @@ var Develop = {
     var callbackCalled = false;
 
     cmd.stdout.on('data', function(data) {
-      // // Print anything our chain process outputs (not much).
-      // // Trim or else we'll have double new lines.
-      // config.logger.log(data.toString().trim());
-
       // Here, we use on('data') to tell us if the application
       // has started correctly. We'll call the callback and setup
       // the configuration once get our first output on stdout.
@@ -41,11 +37,6 @@ var Develop = {
           callback();
         });
       });
-    });
-
-    cmd.stderr.on('data', function(data) {
-      // Log any chain errors.
-      // config.logger.log(data.toString().trim());
     });
 
     cmd.on('error', function(err) {

--- a/lib/develop.js
+++ b/lib/develop.js
@@ -1,0 +1,85 @@
+var ipc = require('node-ipc');
+var path = require('path');
+var spawn = require('child_process').spawn;
+
+var Develop = {
+  start: function(testrpcOptions, callback) {
+    var chainPath;
+
+    // The path to the dev env process depends on whether or not
+    // we're running in the bundled version. If not, use chain.js
+    // directly, otherwise let the bundle point at the bundled version.
+    if (typeof BUNDLE_CHAIN_FILENAME != "undefined") {
+      // Remember: In the bundled version, __dirname refers to the
+      // build directory where cli.bundled.js and cli.chain.js live.
+      chainPath = path.join(__dirname, BUNDLE_CHAIN_FILENAME);
+    } else {
+      chainPath = path.join(__dirname, "../", "chain.js");
+    }
+
+    var cmd = spawn("node", [chainPath, JSON.stringify(testrpcOptions)], {
+      detached: true
+    });
+
+    var callbackCalled = false;
+
+    cmd.stdout.on('data', function(data) {
+      // // Print anything our chain process outputs (not much).
+      // // Trim or else we'll have double new lines.
+      // config.logger.log(data.toString().trim());
+
+      // Here, we use on('data') to tell us if the application
+      // has started correctly. We'll call the callback and setup
+      // the configuration once get our first output on stdout.
+      // Note: Chain errors go to stderr (see below).
+      if (callbackCalled) return;
+
+      callbackCalled = true;
+
+      ipc.connectTo('truffleDevelop', function() {
+        ipc.of.truffleDevelop.on('connect', function() {
+          callback();
+        });
+      });
+    });
+
+    cmd.stderr.on('data', function(data) {
+      // Log any chain errors.
+      // config.logger.log(data.toString().trim());
+    });
+
+    cmd.on('error', function(err) {
+      // If ther'es a bigger error, throw it.
+      throw err;
+    });
+  },
+
+  connect: function(callback) {
+    ipc.config.maxRetries = 0;
+    ipc.config.silent = true;
+
+    ipc.connectTo('truffleDevelop', function() {
+      ipc.of.truffleDevelop.on('error', function(error) {
+        callback(error);
+      });
+
+      ipc.of.truffleDevelop.on('connect', function() {
+        callback();
+      });
+    });
+  },
+
+  connectOrStart: function(testrpcOptions, callback) {
+    var self = this;
+
+    this.connect(function(error) {
+      if (error) {
+        self.start(testrpcOptions, function() { callback(true); });
+      } else {
+        callback(false);
+      }
+    });
+  }
+};
+
+module.exports = Develop;

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -107,45 +107,26 @@ var Environment = {
     });
   },
 
-  develop: function(config, callback) {
+  develop: function(config, testrpcOptions, callback) {
     var self = this;
 
     expect.options(config, [
       "networks",
-      "logger"
     ]);
 
     var network = "develop";
-    var network_id = 4447;
-    var seed = "yum chocolate";
-    var host = "localhost";
-    var port = 9545;
+    var url = `http://${testrpcOptions.host}:${testrpcOptions.port}/`;
 
-    var url = "http://" + host + ":" + port + "/";
-
-    var options = {
-      host: host,
-      port: port,
-      network_id: network_id,
-      seed: seed,
-      gasLimit: config.gas
+    config.networks[network] = {
+      network_id: testrpcOptions.network_id,
+      provider: function() {
+        return new Web3.providers.HttpProvider(url);
+      }
     };
 
-    Develop.connectOrStart(options, function(started) {
-      config.logger.log("Truffle Develop " + (started ? "started." : "connected."));
-      config.logger.log();
+    config.network = network;
 
-      config.networks[network] = {
-        network_id: network_id,
-        provider: function() {
-          return new Web3.providers.HttpProvider(url);
-        }
-      };
-
-      config.network = network;
-
-      Environment.detect(config, callback);
-    });
+    Environment.detect(config, callback);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "chokidar": "^1.4.2",
     "colors": "^1.1.2",
     "cpr": "^0.4.3",
+    "debug": "^3.1.0",
     "del": "^2.2.0",
     "diff": "1.4.0",
     "ethereumjs-testrpc": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",
     "node-dir": "0.1.16",
+    "node-ipc": "^9.1.1",
     "original-require": "^1.0.0",
     "serve-static": "^1.10.0",
     "spawn-args": "^0.1.0",


### PR DESCRIPTION
trufflesuite/truffle#571

Change the behavior of `truffle develop` and the underlying `chain.js` process to support a cluster of `develop` sessions.

This adds:
- `truffle develop --log` to view TestRPC log output
- `truffle develop --log --console` to view TestRPC log output and also open a repl