### PR TITLE
Fix `truffle develop` on Windows

### DIFF
--- a/chain.js
+++ b/chain.js
@@ -3,6 +3,13 @@
 var IPC = require("node-ipc").IPC;
 var TestRPC = require("ethereumjs-testrpc");
 var path = require("path");
+var debug = require("debug");
+
+/*
+ * Loggers
+ */
+var ipcDebug = debug("chain:ipc");
+
 
 /*
  * Options
@@ -297,6 +304,8 @@ var supervisor = new Supervisor({
   retry: 1500,
   logger: ipcLogger.log.bind(ipcLogger)
 });
+
+ipcLogger.subscribe(ipcDebug);
 
 options.logger = {log: testrpcLogger.log.bind(testrpcLogger)};
 

--- a/lib/develop.js
+++ b/lib/develop.js
@@ -29,6 +29,10 @@ var Develop = {
   },
 
   connect: function(options, callback) {
+    var debugServer = debug('develop:ipc:server');
+    var debugClient = debug('develop:ipc:client');
+    var debugRPC = debug('develop:testrpc');
+
     if (typeof options === 'function') {
       callback = options;
       options = {};
@@ -42,9 +46,10 @@ var Develop = {
     var ipc = new IPC();
     ipc.config.appspace = "truffle.";
 
-    var debugServer = debug('develop:ipc:server');
-    var debugClient = debug('develop:ipc:client');
-    var debugRPC = debug('develop:testrpc');
+    // set connectPath explicitly
+    var dirname = ipc.config.socketRoot;
+    var basename = `${ipc.config.appspace}${ipcNetwork}`;
+    var connectPath = path.join(dirname, basename);
 
     ipc.config.silent = !debugClient.enabled;
     ipc.config.logger = debugClient;
@@ -80,7 +85,7 @@ var Develop = {
       ipc.disconnect(ipcNetwork);
     }
 
-    ipc.connectTo(ipcNetwork, function() {
+    ipc.connectTo(ipcNetwork, connectPath, function() {
       ipc.of[ipcNetwork].on('destroy', function() {
         callback(new Error("IPC connection destroyed"));
       });


### PR DESCRIPTION
- Add logging for chain.js
- Use explicitly set path for `ipc.connectTo`