### PR TITLE
Adding help flag and adjusting command builders to make them clearer

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -11,6 +11,7 @@ function Command(commands) {
     args = args.command(commands[command]);
   });
 
+  args = args.help();
   this.args = args;
 };
 

--- a/lib/commands/compile.js
+++ b/lib/commands/compile.js
@@ -5,6 +5,11 @@ var command = {
     all: {
       type: "boolean",
       default: false
+    },
+    network: {
+      type: 'string',
+      description: 'Specify the network to use, saving artifacts specific to that network',
+      default: 'development'
     }
   },
   run: function (options, done) {
@@ -13,6 +18,7 @@ var command = {
 
     var config = Config.detect(options);
     Contracts.compile(config, done);
+    console.log(config.network())
   }
 }
 

--- a/lib/commands/console.js
+++ b/lib/commands/console.js
@@ -1,7 +1,17 @@
 var command = {
   command: 'console',
   description: 'Run a console with contract abstractions and commands available',
-  builder: {},
+  builder: {
+    'verbose-rpc' : {
+      type: 'boolean',
+      default: false
+    },
+    'network' : {
+      type: 'string',
+      description: 'Specify the network to use, saving artifacts specific to that network',
+      default: 'development'
+    }
+  },
   run: function (options, done) {
     var Config = require("truffle-config");
     var Console = require("../console");

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -1,5 +1,5 @@
 var command = {
-  command: 'create',
+  command: 'create <type> <name>',
   description: 'Helper to create new contracts, migrations and tests',
   builder: {},
   run: function (options, done) {

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -1,12 +1,7 @@
 var command = {
   command: 'create',
   description: 'Helper to create new contracts, migrations and tests',
-  builder: {
-    all: {
-      type: "boolean",
-      default: false
-    }
-  },
+  builder: {},
   run: function (options, done) {
     var Config = require("truffle-config");
     var ConfigurationError = require("../errors/configurationerror");

--- a/lib/commands/debug.js
+++ b/lib/commands/debug.js
@@ -2,8 +2,9 @@ var command = {
   command: 'debug',
   description: 'Interactively debug any transaction on the blockchain (experimental)',
   builder: {
-    _: {
-      type: "string"
+    "transaction": {
+      type: "string",
+      describe: "Hash of transaction to be debugged"
     }
   },
   run: function (options, done) {
@@ -19,11 +20,11 @@ var command = {
     Environment.detect(config, function(err) {
       if (err) return done(err);
 
-      if (config._.length == 0) {
+      if (!config.transaction) {
         return done(new Error("Please specify a transaction hash as the first parameter in order to debug that transaction. i.e., truffle debug 0x1234..."));
       }
 
-      var tx_hash = config._[0];
+      var tx_hash = config.transaction;
 
       var bugger = new Debugger(config);
       var lastCommand = "n";

--- a/lib/commands/exec.js
+++ b/lib/commands/exec.js
@@ -1,9 +1,11 @@
 var command = {
-  command: 'exec',
+  command: 'exec <file>',
   description: 'Execute a JS module within this Truffle environment',
   builder: {
-    file: {
-      type: "string"
+    network: {
+      description: 'Specify the network to use, using artifacts specific to that network.',
+      type: 'string',
+      default: 'development'
     }
   },
   run: function (options, done) {
@@ -17,10 +19,6 @@ var command = {
     var config = Config.detect(options);
 
     var file = options.file;
-
-    if (file == null && options._.length > 0) {
-      file = options._[0];
-    }
 
     if (file == null) {
       done(new ConfigurationError("Please specify a file, passing the path of the script you'd like the run. Note that all scripts *must* call process.exit() when finished."));

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -1,14 +1,10 @@
 var command = {
-  command: 'install',
+  command: 'install [packages...]',
   description: 'Install a package from the Ethereum Package Registry',
   builder: {},
   run: function (options, done) {
     var Config = require("truffle-config");
     var Package = require("../package");
-
-    if (options._ && options._.length > 0) {
-      options.packages = options._;
-    }
 
     var config = Config.detect(options);
     Package.install(config, done);

--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -4,10 +4,11 @@ var command = {
   builder: {
     reset: {
       type: "boolean",
+      describe: 'Run all migrations from the beginning, instead of running from the last completed migration',
       default: false
     },
     "compile-all": {
-      describe: "recompile all contracts",
+      describe: "Recompile all contracts",
       type: "boolean",
       default: false
     },
@@ -19,6 +20,15 @@ var command = {
     f: {
       describe: "Specify a migration number to run from",
       type: "number"
+    },
+    network: {
+      describe: "Network to deploy to",
+      type: "string"
+    },
+    'verbose-rpc': {
+      describe: 'Log communication between Truffle and the RPC.',
+      type: "boolean",
+      default: false
     }
   },
   run: function (options, done) {

--- a/lib/commands/opcode.js
+++ b/lib/commands/opcode.js
@@ -1,27 +1,18 @@
 var command = {
-  command: 'opcode',
-  description: 'Print the compiled opcodes for a given contract',
-  builder: {
-    all: {
-      type: "boolean",
-      default: false
-    }
-  },
+  command: 'opcode <contract>',
+  description: 'Print the compiled opcodes for the given contract',
+  builder: {},
   run: function (options, done) {
     var Config = require("truffle-config");
     var TruffleError = require("truffle-error");
     var Contracts = require("../contracts");
     var CodeUtils = require("truffle-code-utils");
 
-    if (options._.length == 0) {
-      return done(new TruffleError("Please specify a contract name."));
-    }
-
     var config = Config.detect(options);
     Contracts.compile(config, function(err) {
       if (err) return done(err);
 
-      var contractName = options._[0];
+      var contractName = options.contract;
       var Contract;
       try {
         Contract = config.resolver.require(contractName);

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -5,6 +5,11 @@ var command = {
     port: {
       alias: "p",
       default: "8080"
+    },
+    network: {
+      type: 'string',
+      description: 'Specify the network to use, using artifacts specific to that network',
+      default: 'development'
     }
   },
   run: function (options, done) {

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -1,7 +1,23 @@
 var command = {
   command: 'test',
   description: 'Run Mocha and Solidity tests',
-  builder: {},
+  builder: {
+    'compile-all': {
+      type: 'boolean',
+      description: 'Compile all contracts instead of intelligently choosing',
+      default: false
+    },
+    'verbose-rpc': {
+      type: 'boolean',
+      description: 'Log communication between Truffle and the RPC',
+      default: false
+    },
+    network: {
+      type: 'string',
+      description: 'Specify the network to use, using artifacts specific to that network',
+      default: 'development'
+    }
+  },
   run: function (options, done) {
     var OS = require("os");
     var dir = require("node-dir");

--- a/lib/commands/unbox.js
+++ b/lib/commands/unbox.js
@@ -48,7 +48,7 @@ function formatCommands(commands) {
 }
 
 var command = {
-  command: 'unbox',
+  command: 'unbox <box>',
   description: 'Unbox Truffle project',
   builder: {},
   run: function(options, done) {
@@ -60,7 +60,7 @@ var command = {
       logger: console
     });
 
-    var url = normalizeURL(options._[0]);
+    var url = normalizeURL(options.box);
 
     Box.unbox(url, config.working_directory, {logger: config.logger})
       .then(function(boxConfig) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "truffle-resolver": "^4.0.0",
     "truffle-solidity-utils": "^1.1.0",
     "web3": "^0.20.1",
-    "yargs": "^6.6.0"
+    "yargs": "^8.0.0"
   },
   "bin": {
     "truffle": "./cli.js",


### PR DESCRIPTION
This PR adds the help flag to the general command and each sub-command. Command builders have been adjusted to give more details and reflect what's going on. Where possible, I've offloaded checking optionality to yargs, instead of doing it manually.

