### PR TITLE
Allow JS tests to run twice in succession in `truffle develop`

### DIFF
--- a/lib/commands/develop.js
+++ b/lib/commands/develop.js
@@ -67,7 +67,7 @@ var command = {
         config.logger.log(`Truffle Develop started at ${url}`);
         config.logger.log();
       } else {
-        config.logger.log(`Connected to exiting Truffle Develop session at ${url}`);
+        config.logger.log(`Connected to existing Truffle Develop session at ${url}`);
         config.logger.log();
       }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -16,6 +16,7 @@ var SolidityUtils = require("truffle-solidity-utils");
 var Migrate = require("truffle-migrate");
 var Profiler = require("truffle-compile/profiler.js");
 var async = require("async");
+var originalrequire = require("original-require");
 
 chai.use(require("./assertions"));
 
@@ -74,7 +75,7 @@ var Test = {
       // There's an idiosyncracy in Mocha where the same file can't be run twice
       // unless we delete the `require` cache.
       // https://github.com/mochajs/mocha/issues/995
-      delete require.cache[file];
+      delete originalrequire.cache[file];
 
       mocha.addFile(file);
     });


### PR DESCRIPTION
Fix for trufflesuite/truffle#585

Mocha stores some state in the `require` cache, which wasn't getting cleared in bundled Truffle, because it was clearing webpack's `require`, not the `require` according to Mocha.