### PR TITLE
Add support note / potential bug warning to debugger

### DIFF
--- a/lib/commands/debug.js
+++ b/lib/commands/debug.js
@@ -43,6 +43,11 @@ var command = {
         return "(" + commandId + ") " + commandReference[commandId];
       };
 
+      config.logger.log("")
+      config.logger.log("Note: This feature's in beta. Please discuss any issues you find in our Gitter channel!");
+      config.logger.log("https://gitter.im/ConsenSys/truffle");
+      config.logger.log("");
+
       config.logger.log("Gathering transaction data...");
       config.logger.log("");
 
@@ -87,9 +92,6 @@ var command = {
           config.logger.log("")
           config.logger.log(help);
 
-          config.logger.log("");
-          config.logger.log("Thank you for trying out the Truffle Debugger!");
-          config.logger.log("This is a new feature and may have bugs. Please report any issues in our Gitter <https://gitter.im/ConsenSys/truffle>.");
           config.logger.log("");
         }
 

--- a/lib/commands/debug.js
+++ b/lib/commands/debug.js
@@ -86,6 +86,10 @@ var command = {
 
           config.logger.log("")
           config.logger.log(help);
+
+          config.logger.log("");
+          config.logger.log("Thank you for trying out the Truffle Debugger!");
+          config.logger.log("This is a new feature and may have bugs. Please report any issues in our Gitter <https://gitter.im/ConsenSys/truffle>.");
           config.logger.log("");
         }
 


### PR DESCRIPTION
trufflesuite/truffle#642

<img width="964" alt="screen shot 2017-10-30 at 4 56 25 pm" src="https://user-images.githubusercontent.com/151065/32195438-a037307c-bd93-11e7-88d2-ed3f7b9ed1af.png">

Add as help information, displays on first run and for `help` command.