### PR TITLE
Fix column calculation for debugger (hackily)

### DIFF
--- a/lib/commands/debug.js
+++ b/lib/commands/debug.js
@@ -182,12 +182,18 @@ var command = {
           pointer += "^";
           column += 1;
 
-          var end_column = range.end.column;
+          var end_column;
 
-          if (range.end.line != range.start.line) {
+          if (range.end) {
+            end_column = range.end.column;
+
+            if (range.end.line != range.start.line) {
+              end_column = line.length - 1;
+            }
+          } else {
             end_column = line.length - 1;
           }
-
+          
           for (; column < end_column; column++) {
             pointer += "^";
           }


### PR DESCRIPTION
https://github.com/trufflesuite/truffle/issues/609

Uses end of line if variables aren't defined correctly