### PR TITLE
Return the extended solc version from `truffle version`

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -1,5 +1,5 @@
 var pkg = require("../package.json");
-var solcpkg = require("solc/package.json");
+var solc = require("solc");
 
 var bundle_version = null;
 
@@ -11,5 +11,5 @@ if (typeof BUNDLE_VERSION != "undefined") {
 module.exports = {
   core: pkg.version,
   bundle: bundle_version,
-  solc: solcpkg.version
+  solc: solc.version()
 };


### PR DESCRIPTION
Hey truffle team,

Thanks for all you do for the community!

I was trying to find the exact version of solc truffle was using so I could upload my contract metadata to swarm. I ran into [this answer](https://ethereum.stackexchange.com/a/18210)  on stack exchange but that seemed sort of hacky.

Let me know if there's a better way to do this.

Thanks again!

-Mason