### PR TITLE
update test.js with simple warning

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -210,6 +210,8 @@ var Test = {
       async.each(contracts, function(contract, finished) {
         var file = file_hash[contract.contract_name];
 
+        if (file == undefined) console.log("\x1b[31m", "WARNING: file " + contract.contract_name + ".sol NOT FOUND - the name of the .sol file must be the same as the containing contract" +"\x1b[0m");
+        
         SolidityUtils.ordered_abi(file, contract.abi, contract.contract_name, function(err, ordered) {
           if (err) return finished(err);
 


### PR DESCRIPTION
simple user-friendly addition to help users running tests understand where the mistake in naming the file of a test contract probably is.

## Problem
if  a developer names the .sol file containing the test contract with a different name than the contract itself (ie file `testAdoption.sol`, with a leading small t,  and the contract contained is `TestAdoption`, with a leading capital T)

test.js would only output a cryptic error suggesting that the file has not been found, but not suggesting which file
Example of the error
```
TypeError: path must be a string or Buffer
    at Object.fs.readFile (fs.js:358:11)
    at Object.ordered_abi (~/.nvm/versions/node/v8.9.0/lib/node_modules/truffle/build/cli.bundled.js:202173:8)
```

## Solution
A simple warning to inform which file was wrong
The console will now output a more informative

```
WARNING: file TestAdoption.sol NOT FOUND - the name of the .sol file must be the same as the containing contract
``` 

## Improvements
do you have a style guide or preference for the appropriate console warning? 
For now I've colored it red ("\x1b[31m") and reset it at the end ("\x1b[0m")

Also in this scope there doesn't seem to be a config.logger.warn
but I kept this improvement as light as possible (1 liner)