### PR TITLE
Fix solidity testing

### DIFF
--- a/lib/testing/soliditytest.js
+++ b/lib/testing/soliditytest.js
@@ -7,6 +7,7 @@ var artifactor = require("truffle-artifactor");
 var contract = require("truffle-contract");
 var series = require("async").series;
 var path = require("path");
+var utils = require("web3").utils
 
 var SolidityTest = {
   define: function(abstraction, dependency_paths, runner, mocha) {
@@ -30,6 +31,12 @@ var SolidityTest = {
 
     // Function that checks transaction logs to see if a test failed.
     function processResult(result) {
+      if (result.receipt.status != null) {
+        // note: testrpc is numeric, geth is hex
+        if (utils.toBigNumber(result.receipt.status).toNumber() != 1) {
+          throw new Error("transaction revert");
+        }
+      }
       result.logs.forEach(function(log) {
         if (log.event == "TestEvent" && log.args.result == false) {
           throw new Error(log.args.message);


### PR DESCRIPTION
Fix critical problem that solidity testing will success even if there is an error occurs.

According to EIP658, if the transaction success, the transaction receipt will contains status with value `0x1`, and revert is `0x0`.
