### PR TITLE
Copy gasPrice and gasLimit with dry-run

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -97,9 +97,11 @@ var Environment = {
         network_id: config.network_id,
         provider: TestRPC.provider({
           fork: config.provider,
-          unlocked_accounts: accounts
+          unlocked_accounts: accounts,
         }),
-        from: config.from
+        from: config.from,
+        gasLimit: upstreamConfig.gasLimit,
+        gasPrice: upstreamConfig.gasPrice
       }
       config.network = forkedNetwork;
 


### PR DESCRIPTION
Related to issue trufflesuite/truffle#680

The problem was the gasPrice and gasLimit of the network being ignored when running a dry-run, as they were not copied over in the forked network

