### PR TITLE
Add tests to check ancestor recompilation when descendant source gets updated

### DIFF
--- a/test/compile.js
+++ b/test/compile.js
@@ -57,10 +57,11 @@ describe("compile", function() {
     });
   });
 
-  it('compiles contract and dependencies after an update', function(done) {
+  it('compiles updated contract and descendents', function(done) {
     this.timeout(10000);
 
     var file_to_update = path.resolve(path.join(config.contracts_directory, "MetaCoin.sol"));
+    var stat = fs.statSync(file_to_update);
 
     // Update the modification time to simulate an edit.
     var newTime = new Date().getTime();
@@ -73,6 +74,35 @@ describe("compile", function() {
       if (err) return done(err);
 
       assert.equal(Object.keys(contracts).length, 2, "Expected MetaCoin and ConvertLib to be compiled");
+
+      // reset time
+      fs.utimesSync(file_to_update, stat.atime, stat.mtime);
+
+      done();
+    });
+  });
+
+  it('compiles updated contract and its ancestors', function(done) {
+    this.timeout(10000);
+
+    var file_to_update = path.resolve(path.join(config.contracts_directory, "ConvertLib.sol"));
+    var stat = fs.statSync(file_to_update);
+
+    // Update the modification time to simulate an edit.
+    var newTime = new Date().getTime();
+    fs.utimesSync(file_to_update, newTime, newTime);
+
+    Contracts.compile(config.with({
+      all: false,
+      quiet: true
+    }), function(err, contracts) {
+      if (err) return done(err);
+
+      assert.equal(Object.keys(contracts).length, 2, "Expected MetaCoin and ConvertLib to be compiled");
+
+      // reset time
+      fs.utimesSync(file_to_update, stat.atime, stat.mtime);
+
       done();
     });
   });


### PR DESCRIPTION
Hopefully addressing some of the `invalid number of arguments to a Solidity function` problems.

Refs: https://github.com/trufflesuite/truffle/issues/596 https://github.com/trufflesuite/truffle/issues/698 https://github.com/trufflesuite/truffle/issues/706 
(although these may or may not be the same issue)

- Make descendent-testing reset timestamps
- Add test for ancestor checking