### PR TITLE
Add Chai expect tests

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -237,6 +237,7 @@ var Test = {
     return new Promise(function(accept, reject) {
       global.web3 = web3;
       global.assert = chai.assert;
+      global.expect = chai.expect;
       global.artifacts = {
         require: function(import_path) {
           return test_resolver.require(import_path);


### PR DESCRIPTION
This patch adds Chai's `expect` as a global function alongside `assert` for truffle tests.

`expect` is useful because it provides a number of tests that aren't available with `assert`, for example equality of arrays with the `eql()` function.