### PR TITLE
Add migrate --without-compile

### DIFF
--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -19,6 +19,11 @@ var command = {
     f: {
       describe: "Specify a migration number to run from",
       type: "number"
+    },
+    "without-compile": {
+      describe: "Run migrations without compiling contracts",
+      type: "boolean",
+      default: false
     }
   },
   run: function (options, done) {
@@ -85,8 +90,13 @@ var command = {
       }
     };
 
-    Contracts.compile(config, function(err) {
-      if (err) return done(err);
+    var withoutCompile = options.withoutCompile === true;
+
+    if (withoutCompile == false){
+      Contracts.compile(config, function(err) {
+        if (err) return done(err);
+      });
+    }
 
       Environment.detect(config, function(err) {
         if (err) return done(err);
@@ -107,7 +117,6 @@ var command = {
           runMigrations(done);
         }
       });
-    });
   }
 }
 


### PR DESCRIPTION
The current migrate command compile contracts before migrations. 
This PR add an option to migrate already compiled contracts (json files).
By having this option , one can publish its already compiled contracts and let others do the deployment without the need to compile.

 