### PR TITLE
Re-deploy contracts between test runs with non-ganache clients

### DIFF
--- a/lib/testing/testrunner.js
+++ b/lib/testing/testrunner.js
@@ -26,8 +26,8 @@ function TestRunner(options) {
   this.initial_resolver = options.resolver;
   this.provider = options.provider;
 
-  this.can_shapshot = false;
-  this.first_snapshot = false;
+  this.can_snapshot = false;
+  this.first_snapshot = true;
   this.initial_snapshot = null;
   this.known_events = {};
   this.web3 = new Web3();
@@ -89,7 +89,7 @@ TestRunner.prototype.initialize = function(callback) {
         self.initial_snapshot = initial_snapshot;
       }
 
-      self.first_snapshot = false
+      self.first_snapshot = false;
 
       afterStateReset();
     });

--- a/lib/testing/testrunner.js
+++ b/lib/testing/testrunner.js
@@ -27,6 +27,7 @@ function TestRunner(options) {
   this.provider = options.provider;
 
   this.can_shapshot = false;
+  this.first_snapshot = false;
   this.initial_snapshot = null;
   this.known_events = {};
   this.web3 = new Web3();
@@ -77,7 +78,7 @@ TestRunner.prototype.initialize = function(callback) {
     });
   };
 
-  if (self.initial_snapshot == null) {
+  if (self.first_snapshot) {
     // // Make the initial deployment (full migration).
     // self.deploy(function(err) {
     //   if (err) return callback(err);
@@ -87,6 +88,9 @@ TestRunner.prototype.initialize = function(callback) {
         self.can_snapshot = true;
         self.initial_snapshot = initial_snapshot;
       }
+
+      self.first_snapshot = false
+
       afterStateReset();
     });
     //});
@@ -98,7 +102,7 @@ TestRunner.prototype.initialize = function(callback) {
 TestRunner.prototype.deploy = function(callback) {
   Migrate.run(this.config.with({
     reset: true,
-    //quiet: true
+    quiet: true
   }), callback);
 };
 


### PR DESCRIPTION
As described in https://github.com/trufflesuite/truffle/issues/760, Truffle currently does not create a clean room environment for each test file run when using a non-ganache Ethereum client like Parity or Geth.

The issue seems to be `self.resetState` is never called here https://github.com/trufflesuite/truffle-core/blob/develop/lib/testing/testrunner.js#L94 when using a non-ganache Ethereum client. This check from https://github.com/trufflesuite/truffle-core/blob/develop/lib/testing/testrunner.js#L80

```
if (self.initial_snapshot == null)
```

will always evaluate to true when using a non-ganache Ethereum client because an initial snapshot is never created. As a result, we never get to the code path with `self.resetState` which has the logic for re-deploying contracts between test file runs. This PR makes a small change so that code path will be run between test file runs.