### PR TITLE
[BugFix] Assert.sol - notEqual broken for list types, fixes #101

### DIFF
--- a/lib/testing/Assert.sol
+++ b/lib/testing/Assert.sol
@@ -852,17 +852,18 @@ library Assert {
         Returns:
             result (bool) - The result.
     */
-    function notEqual(uint[] arrA, uint[] arrB, string message) public returns (bool) {
-        var r = arrA.length == arrB.length;
-        if (r) {
+    function notEqual(uint[] arrA, uint[] arrB, string message) public returns (bool result) {
+        result = arrA.length == arrB.length;
+        if (result) {
             for (uint i = 0; i < arrA.length; i++) {
-                if (arrA[i] == arrB[i]) {
-                    r = true;
+                if (arrA[i] != arrB[i]) {
+                    result = false;
                     break;
                 }
             }
         }
-        _report(!r, message);
+        result = !result;
+        _report(result, message);
     }
 
     /*
@@ -964,17 +965,18 @@ library Assert {
         Returns:
             result (bool) - The result.
     */
-    function notEqual(int[] arrA, int[] arrB, string message) public returns (bool) {
-        var r = arrA.length == arrB.length;
-        if (r) {
+    function notEqual(int[] arrA, int[] arrB, string message) public returns (bool result) {
+        result = arrA.length == arrB.length;
+        if (result) {
             for (uint i = 0; i < arrA.length; i++) {
-                if (arrA[i] == arrB[i]) {
-                    r = true;
+                if (arrA[i] != arrB[i]) {
+                    result = false;
                     break;
                 }
             }
         }
-        _report(!r, message);
+        result = !result;
+        _report(result, message);
     }
 
     /*
@@ -1076,17 +1078,18 @@ library Assert {
         Returns:
             result (bool) - The result.
     */
-    function notEqual(address[] arrA, address[] arrB, string message) public returns (bool) {
-        var r = arrA.length == arrB.length;
-        if (r) {
+    function notEqual(address[] arrA, address[] arrB, string message) public returns (bool result) {
+        result = arrA.length == arrB.length;
+        if (result) {
             for (uint i = 0; i < arrA.length; i++) {
-                if (arrA[i] == arrB[i]) {
-                    r = true;
+                if (arrA[i] != arrB[i]) {
+                    result = false;
                     break;
                 }
             }
         }
-        _report(!r, message);
+        result = !result;
+        _report(result, message);
     }
 
     /*
@@ -1188,17 +1191,18 @@ library Assert {
         Returns:
             result (bool) - The result.
     */
-    function notEqual(bytes32[] arrA, bytes32[] arrB, string message) public returns (bool) {
-        var r = arrA.length == arrB.length;
-        if (r) {
+    function notEqual(bytes32[] arrA, bytes32[] arrB, string message) public returns (bool result) {
+        result = arrA.length == arrB.length;
+        if (result) {
             for (uint i = 0; i < arrA.length; i++) {
-                if (arrA[i] == arrB[i]) {
-                    r = true;
+                if (arrA[i] != arrB[i]) {
+                    result = false;
                     break;
                 }
             }
         }
-        _report(!r, message);
+        result = !result;
+        _report(result, message);
     }
 
     /*


### PR DESCRIPTION
1.  The function is incorrect when the arrays are of the same length
    and have completly different values.
2.  It will also fail when the first values in both arrays match
    regardless of the other values (for length > 1).
3.  This fix applies the `equals` logic and negates it before
    reporting and returning a boolean.