### PR TITLE
Prevent 'truffle create' from overwriting existing files

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -5,7 +5,9 @@ var _ = require("lodash");
 function Command(commands) {
   this.commands = commands;
 
-  var args = yargs();
+  var args = yargs()
+    .boolean(['f', 'force'])
+    .alias('f', 'force');
 
   Object.keys(this.commands).forEach(function(command) {
     args = args.command(commands[command]);

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -38,13 +38,17 @@ var command = {
 
     if (fn == null) return done(new ConfigurationError("Cannot find creation type: " + type));
 
+    var create_options = {
+      force: config.force
+    };
+
     var destinations = {
       "contract": config.contracts_directory,
       "migration": config.migrations_directory,
       "test": config.test_directory
     };
 
-    create[type](destinations[type], name, done);
+    create[type](destinations[type], name, create_options, done);
   }
 }
 

--- a/lib/create.js
+++ b/lib/create.js
@@ -62,7 +62,7 @@ var Create = {
     var to = path.join(directory, name + ".sol");
 
     if (!options.force && fs.existsSync(to)) {
-      console.error('Can not create ' + name + '.sol: file exists');
+      return callback(new Error('Can not create ' + name + '.sol: file exists'));
     }
 
     copy.file(from, to, function(err) {
@@ -83,7 +83,7 @@ var Create = {
     var to = path.join(directory, underscored + ".js");
 
     if (!options.force && fs.existsSync(to)) {
-      console.error('Can not create ' + underscored + '.js: file exists');
+      return callback(new Error('Can not create ' + underscored + '.js: file exists'));
     }
 
     copy.file(from, to, function(err) {
@@ -113,7 +113,7 @@ var Create = {
     var to = path.join(directory, filename);
 
     if (!options.force && fs.existsSync(to)) {
-      console.error('Can not create ' + filename + ': file exists');
+      return callback(new Error('Can not create ' + filename + ': file exists'));
     }
 
     copy.file(from, to, callback);

--- a/lib/create.js
+++ b/lib/create.js
@@ -53,9 +53,17 @@ var toUnderscoreFromCamel = function(string) {
 };
 
 var Create = {
-  contract: function(directory, name, callback) {
+  contract: function(directory, name, options, callback) {
+    if(typeof options == "function") {
+      callback = options;
+    }
+
     var from = templates.contract.filename;
     var to = path.join(directory, name + ".sol");
+
+    if (!options.force && fs.existsSync(to)) {
+      console.error('Can not create ' + name + '.sol: file exists');
+    }
 
     copy.file(from, to, function(err) {
       if (err) return callback(err);
@@ -64,11 +72,19 @@ var Create = {
     });
   },
 
-  test: function(directory, name, callback) {
+  test: function(directory, name, options, callback) {
+    if(typeof options == "function") {
+      callback = options;
+    }
+
     var underscored = toUnderscoreFromCamel(name);
     underscored = underscored.replace(/\./g, "_");
     var from = templates.test.filename;
     var to = path.join(directory, underscored + ".js");
+
+    if (!options.force && fs.existsSync(to)) {
+      console.error('Can not create ' + underscored + '.js: file exists');
+    }
 
     copy.file(from, to, function(err) {
       if (err) return callback(err);
@@ -79,18 +95,26 @@ var Create = {
       });
     });
   },
-  migration: function(directory, name, callback) {
+  migration: function(directory, name, options, callback) {
+    if(typeof options == "function") {
+      callback = options;
+    }
+
     var underscored = toUnderscoreFromCamel(name || "");
     underscored = underscored.replace(/\./g, "_");
     var from = templates.migration.filename;
-    var to = new Date().getTime() / 1000 | 0; // Only do seconds.
+    var filename = new Date().getTime() / 1000 | 0; // Only do seconds.
 
     if (name != null && name != "") {
-      to += "_" + underscored;
+      filename += "_" + underscored;
     }
 
-    to += ".js";
-    to = path.join(directory, to);
+    filename += ".js";
+    var to = path.join(directory, filename);
+
+    if (!options.force && fs.existsSync(to)) {
+      console.error('Can not create ' + filename + ': file exists');
+    }
 
     copy.file(from, to, callback);
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "truffle-solidity-utils": "^1.1.1",
     "truffle-workflow-compile": "^1.0.0",
     "web3": "^0.20.1",
-    "yargs": "^6.6.0"
+    "yargs": "^8.0.2"
   },
   "bin": {
     "truffle": "./cli.js",


### PR DESCRIPTION
Discussed in trufflesuite/truffle#809

`truffle create` will no longer overwrite existing files, unless passed the -f flag