### PR TITLE
Reject creation of entities with invalid names

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -35,7 +35,7 @@ var command = {
     }
 
     if (!/^[a-zA-Z_$][a-zA-Z_$0-9]*$/.test(name)) {
-      return done(new ConfigurationError("The name " + name + " is invalid. Please enter a valid name to create."));
+      return done(new ConfigurationError("The name " + name + " is invalid. Please enter a valid name using alpha-numeric characters."));
     }
 
     var fn = create[type];

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -34,6 +34,10 @@ var command = {
       return done(new ConfigurationError("Please specify the name of item to create. Example: truffle create contract MyContract"));
     }
 
+    if (!/^[a-zA-Z_$][a-zA-Z_$0-9]*$/.test(name)) {
+      return done(new ConfigurationError("The name " + name + " is invalid. Please enter a valid name to create."));
+    }
+
     var fn = create[type];
 
     if (fn == null) return done(new ConfigurationError("Cannot find creation type: " + type));


### PR DESCRIPTION
Fixes trufflesuite/truffle#790

Rejects creation of entities that are not valid [Solidity identifiers](https://github.com/ethereum/solidity/blob/develop/docs/grammar.txt).