### PR TITLE
Catch error at 'getFiles'

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -44,6 +44,8 @@ var command = {
     };
 
     getFiles(function(err, files) {
+      if (err) return done(err);
+
       files = files.filter(function(file) {
         return file.match(config.test_file_extension_regexp) != null;
       });


### PR DESCRIPTION
Fixes [truffle 837](https://github.com/trufflesuite/truffle/issues/837). Stops this from happening (unhelpfully):
```
TypeError: Cannot read property 'filter' of undefined
    at truffle-core/lib/commands/test.js:47:1
    at truffle-core/~/node-dir/lib/paths.js:72:1
    at FSReqWrap.oncomplete (fs.js:166:21)
```