### PR TITLE
Update tests for minimized compilation

### DIFF
--- a/lib/testing/soliditytest.js
+++ b/lib/testing/soliditytest.js
@@ -104,6 +104,7 @@ var SolidityTest = {
 
       compile.with_dependencies(runner.config.with({
         paths: [
+          "truffle/Assert.sol",
           "truffle/DeployedAddresses.sol",
           path.join(__dirname, "SafeSend.sol")
         ],

--- a/test/compile.js
+++ b/test/compile.js
@@ -57,31 +57,6 @@ describe("compile", function() {
     });
   });
 
-  it('compiles updated contract and descendents', function(done) {
-    this.timeout(10000);
-
-    var file_to_update = path.resolve(path.join(config.contracts_directory, "MetaCoin.sol"));
-    var stat = fs.statSync(file_to_update);
-
-    // Update the modification time to simulate an edit.
-    var newTime = new Date().getTime();
-    fs.utimesSync(file_to_update, newTime, newTime);
-
-    Contracts.compile(config.with({
-      all: false,
-      quiet: true
-    }), function(err, contracts) {
-      if (err) return done(err);
-
-      assert.equal(Object.keys(contracts).length, 2, "Expected MetaCoin and ConvertLib to be compiled");
-
-      // reset time
-      fs.utimesSync(file_to_update, stat.atime, stat.mtime);
-
-      done();
-    });
-  });
-
   it('compiles updated contract and its ancestors', function(done) {
     this.timeout(10000);
 

--- a/test/ethpm.js
+++ b/test/ethpm.js
@@ -153,6 +153,8 @@ describe('EthPM integration', function() {
         assert.isNotNull(contracts["transferable"]);
 
         fs.readdir(config.contracts_build_directory, function(err, files) {
+          if (err) return done(err);
+
           var found = [false, false];
           var search = ["owned", "transferable"];
 

--- a/test/npm.js
+++ b/test/npm.js
@@ -15,7 +15,7 @@ describe('NPM integration', function() {
   var parentContractSource = "pragma solidity ^0.4.2; import 'fake_source/contracts/Module.sol'; contract Parent {}";
 
   before("Create a sandbox", function(done) {
-    this.timeout(10000);
+    this.timeout(15000);
     Box.sandbox(function(err, result) {
       if (err) return done(err);
       config = result;

--- a/test/profiler.js
+++ b/test/profiler.js
@@ -23,12 +23,13 @@ describe('profiler', function() {
 
   it('profiles example project successfully', function(done) {
     Profiler.required_sources(config.with({
-      paths: ["./MetaCoin.sol"],
+      paths: ["./ConvertLib.sol"],
       base_path: config.contracts_directory
-    }), function(err, result) {
+    }), function(err, allSources, compilationTargets) {
       if (err) return done(err);
 
-      assert.equal(Object.keys(result).length, 2);
+      assert.equal(Object.keys(allSources).length, 3);
+      assert.equal(Object.keys(compilationTargets).length, 2);
       done();
     });
   });

--- a/test/profiler.js
+++ b/test/profiler.js
@@ -29,7 +29,7 @@ describe('profiler', function() {
       if (err) return done(err);
 
       assert.equal(Object.keys(allSources).length, 3);
-      assert.equal(Object.keys(compilationTargets).length, 2);
+      assert.equal(compilationTargets.length, 2);
       done();
     });
   });


### PR DESCRIPTION
Companion to [truffle-compile 53](https://github.com/trufflesuite/truffle-compile/pull/53) which minimizes the compilation set.

+ Removes a test which expects compilation to recompile imported contracts even if they haven't changed. 
+ Updates the `profiler` test. There is a TODO suggesting it be moved to `truffle-compile`. This PR has a [companion test suite]() at `truffle` that covers the same behavior so perhaps it should just be deleted.
+ Adds `Assert.sol` to the list of contracts injected into solidity test compilation. Not sure why this was being excluded but it's necessary that it's present in the list of all sources to pass to solc.

 