### PR TITLE
Add catch for unhandled debugger exceptions

### DIFF
--- a/lib/commands/debug.js
+++ b/lib/commands/debug.js
@@ -455,7 +455,7 @@ var command = {
         // This leaves the process at the whim of the repl; the repl is
         // responsible for closing the process when done.
         done();
-      });
+      }).catch(done);
     });
   }
 }


### PR DESCRIPTION
Oops! This should make debugging errors in truffle-debugger a lot easier.

(h/t to trufflesuite/truffle-debugger#56 for being the straw that broke the camel's back)