### PR TITLE
Compile contracts before running exec

### DIFF
--- a/lib/commands/exec.js
+++ b/lib/commands/exec.js
@@ -4,6 +4,14 @@ var command = {
   builder: {
     file: {
       type: "string"
+    },
+    c: {
+      type: "boolean",
+      default: false
+    },
+    compile: {
+      type: "boolean",
+      default: false
     }
   },
   run: function (options, done) {
@@ -39,13 +47,21 @@ var command = {
         config.logger.log("Using network '" + config.network + "'." + OS.EOL);
       }
 
-      Contracts.compile(config, function(err){
-        if(err) return done(err);
+      // `--compile`
+      if (options.c || options.compile){
+        return Contracts.compile(config, function(err){
+          if(err) return done(err);
 
-        Require.exec(config.with({
-          file: file
-        }), done);
-      });
+          Require.exec(config.with({
+            file: file
+          }), done);
+        });
+      };
+
+      // Just exec
+      Require.exec(config.with({
+        file: file
+      }), done);
     });
   }
 }

--- a/lib/commands/exec.js
+++ b/lib/commands/exec.js
@@ -8,6 +8,7 @@ var command = {
   },
   run: function (options, done) {
     var Config = require("truffle-config");
+    var Contracts = require("truffle-workflow-compile");
     var ConfigurationError = require("../errors/configurationerror");
     var Require = require("truffle-require");
     var Environment = require("../environment");
@@ -38,9 +39,13 @@ var command = {
         config.logger.log("Using network '" + config.network + "'." + OS.EOL);
       }
 
-      Require.exec(config.with({
-        file: file
-      }), done);
+      Contracts.compile(config, function(err){
+        if(err) return done(err);
+
+        Require.exec(config.with({
+          file: file
+        }), done);
+      });
     });
   }
 }


### PR DESCRIPTION
[truffle 908](https://github.com/trufflesuite/truffle/issues/908)

Thesis: `exec` requires the artifacts for any meaningful use and compilation should be part of this command.  Are there any arguments against this as a default - e.g. compilation should be a `-c`?

[Edit: Answer: maybe]

(Adding a unit for `exec` in truffle main repo so we can hit this file in the tests).