### PR TITLE
Close open handlers on exit

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -36,6 +36,8 @@ command.run(process.argv.slice(2), options, function(err) {
     }
     process.exit(1);
   }
+  console.log('Forcing exit...')
+  process.exit(0);
 
   // Don't exit if no error; if something is keeping the process open,
   // like `truffle console`, then let it.

--- a/cli.js
+++ b/cli.js
@@ -36,9 +36,17 @@ command.run(process.argv.slice(2), options, function(err) {
     }
     process.exit(1);
   }
-  console.log('Forcing exit...')
-  process.exit(0);
 
   // Don't exit if no error; if something is keeping the process open,
   // like `truffle console`, then let it.
+
+  // Clear any polling though - `provider-engine` in HDWallet
+  // and `web3 1.0 confirmations` both interval timers wide open.
+  const Timer = process.binding('timer_wrap').Timer;
+  const handles = process._getActiveHandles();
+  handles.forEach(handle => {
+    if (handle instanceof Timer){
+      handle.close();
+    }
+  })
 });

--- a/cli.js
+++ b/cli.js
@@ -40,12 +40,11 @@ command.run(process.argv.slice(2), options, function(err) {
   // Don't exit if no error; if something is keeping the process open,
   // like `truffle console`, then let it.
 
-  // Clear any polling though - `provider-engine` in HDWallet
-  // and `web3 1.0 confirmations` both interval timers wide open.
-  const Timer = process.binding('timer_wrap').Timer;
+  // Clear any polling or open sockets - `provider-engine` in HDWallet
+  // and `web3 1.0 confirmations` both leave interval timers etc wide open.
   const handles = process._getActiveHandles();
   handles.forEach(handle => {
-    if (handle instanceof Timer){
+    if (typeof handle.close === 'function'){
       handle.close();
     }
   })

--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -77,6 +77,8 @@ var command = {
 
           if (needsMigrating) {
             Migrate.run(config, done);
+            console.log('Forcing exit after `migrate.run`');
+            process.exit(0);
           } else {
             config.logger.log("Network up to date.")
             callback();

--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -77,8 +77,6 @@ var command = {
 
           if (needsMigrating) {
             Migrate.run(config, done);
-            console.log('Forcing exit after `migrate.run`');
-            process.exit(0);
           } else {
             config.logger.log("Network up to date.")
             callback();


### PR DESCRIPTION
Believe this safely resolves [truffle 852](https://github.com/trufflesuite/truffle/issues/852) where migrations that rely on a connection to infura or other remote cluster fail to complete. 

Ran examples of the problem with [wtfnode](https://www.npmjs.com/package/wtfnode) which detects which handlers continue to run during a hang and saw both `Timers` (e.g. interval polling from web3 and provider-engine) and `Sockets` (`provider-engine`) being left open. These have `close` methods we can invoke on command exit. 

Have also published this branch to `darq-truffle@roderik` and tested it against `truffle develop` and `truffle console`, everything works. 