### PR TITLE
Update to Mocha 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ganache-cli": "6.1.0-beta.4",
     "lodash": "^4.5.1",
     "mkdirp": "^0.5.1",
-    "mocha": "^3.2.0",
+    "mocha": "^4.1.0",
     "node-dir": "0.1.16",
     "node-emoji": "^1.8.1",
     "node-ipc": "^9.1.1",


### PR DESCRIPTION
Among other things, we're getting the dread `test.titlePath is not a function` error, possibly from mixing and matching mochas here and at truffle.