### PR TITLE
Extract event values correctly

### DIFF
--- a/lib/testing/testrunner.js
+++ b/lib/testing/testrunner.js
@@ -184,8 +184,8 @@ TestRunner.prototype.endTest = function(mocha, callback) {
           value = "<indexed>";
         } else {
           value = values[index];
-          index += 1;
         }
+        index += 1;
 
         return input.name + ": " + value.toString();
       }).join(", ");


### PR DESCRIPTION
Iterates across Web3 1.0 event object correctly, so events with indexed and non-indexed elements print correctly on test failure. Example from EthPM:
```javascript
// Currently
SetCanCall(codeAddress: <indexed>, sig: <indexed>, can: 0xD1243cffdf4da84fc0e91B056dBe7BaCed0b43B2)

// Fixed
SetCanCall(codeAddress: <indexed>, sig: <indexed>, can: true) 
```