### PR TITLE
Ensure ADDRESS_NULL is a strict address literal for Solidity 0.5.0 in testing/Assert.sol

### DIFF
--- a/lib/testing/Assert.sol
+++ b/lib/testing/Assert.sol
@@ -52,7 +52,7 @@ library Assert {
 
     // Constant: ADDRESS_NULL
     // The null address: 0
-    address constant ADDRESS_NULL = 0x0;
+    address constant ADDRESS_NULL = 0x0000000000000000000000000000000000000000;
     // Constant: BYTES32_NULL
     // The null bytes32: 0
     bytes32 constant BYTES32_NULL = 0x0;


### PR DESCRIPTION
This change is fully backwards compatible. An upcoming breaking change will require address literals to be strictly 40 hex digits long. See https://github.com/ethereum/solidity/pull/3534.

Alternatively one could use an explicit conversion: `address(0)` or `address(0x0)`. Let me know which one you prefer.